### PR TITLE
ci: fix broken Cloud Run deploy (migrate to google-github-actions v2)

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -21,13 +21,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    # Authenticate to Google Cloud with the service account key
+    - id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.RUN_SA_KEY }}
 
     # Setup gcloud CLI
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@v2
       with:
-        version: '290.0.1'
-        service_account_key: ${{ secrets.RUN_SA_KEY }}
         project_id: ${{ secrets.GOOGLE_CLOUD_RUN_PROJECT }}
 
     # Build and push image to Google Container Registry


### PR DESCRIPTION
The deploy workflow failed at `Set up job` with `Unable to resolve action GoogleCloudPlatform/github-actions@master` — Google retired that action.

This migrates auth to `google-github-actions/auth@v2` (using the existing `RUN_SA_KEY` secret) + `setup-gcloud@v2`, and bumps `checkout` to v4.

Merging to `master` will re-trigger the Cloud Run deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)