### PR TITLE
ci: publish to Artifact Registry (drop deprecated gcr.io)

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -34,18 +34,18 @@ jobs:
       with:
         project_id: ${{ secrets.GOOGLE_CLOUD_RUN_PROJECT }}
 
-    # Build and push image to Google Container Registry
+    # Build and push image to Artifact Registry
     - name: Build
       run: |-
         gcloud builds submit \
           --quiet \
-          --tag "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA"
+          --tag "$RUN_REGION-docker.pkg.dev/$PROJECT_ID/containers/$SERVICE_NAME:$GITHUB_SHA"
     # Deploy image to Cloud Run
     - name: Deploy
       run: |-
         gcloud run deploy "$SERVICE_NAME" \
           --quiet \
           --region "$RUN_REGION" \
-          --image "gcr.io/$PROJECT_ID/$SERVICE_NAME:$GITHUB_SHA" \
+          --image "$RUN_REGION-docker.pkg.dev/$PROJECT_ID/containers/$SERVICE_NAME:$GITHUB_SHA" \
           --platform "managed" \
           --allow-unauthenticated


### PR DESCRIPTION
Build and deploy via `europe-west1-docker.pkg.dev/$PROJECT_ID/containers/front` instead of `gcr.io`. AR repo + IAM already set up. Merging re-triggers the deploy as the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)