### PR TITLE
fix: broken images (CRA5 require) + drop unused jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "classnames": "^2.2.6",
         "formik": "^2.1.4",
         "headroom.js": "^0.11.0",
-        "jquery": "^3.5.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-helmet": "^6.1.0",
@@ -6282,9 +6281,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.33",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
+      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -13640,12 +13639,6 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "classnames": "^2.2.6",
     "formik": "^2.1.4",
     "headroom.js": "^0.11.0",
-    "jquery": "^3.5.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -20,13 +20,6 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-    integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-    crossorigin="anonymous"></script>
-  <script>window.jQuery || document.write('<script src="/docs/4.4/assets/js/vendor/jquery.slim.min.js"><\/script>')</script>
-  <script src="https://getbootstrap.com/docs/4.4/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-6khuMg9gaYr5AxOqhkVIODVIvm9ynTT5J4V1cfthmT+emCG6yVmEZsRHdxlotUnm"
-    crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -2,6 +2,9 @@ import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 
+import checklistImg from 'assets/img/theme/checklist.svg';
+import reviewImg from 'assets/img/theme/review.svg';
+
 // reactstrap components
 import {
   Badge,
@@ -37,7 +40,7 @@ function BigHero() {
             <img
               alt="..."
               className="img-center img-fluid"
-              src={require("assets/img/theme/checklist.svg")} />
+              src={checklistImg} />
           </div>
         </div>
       </div>
@@ -53,7 +56,7 @@ function Features() {
           <img
             alt="..."
             className="img-fluid floating"
-            src={require("assets/img/theme/review.svg")} />
+            src={reviewImg} />
         </Col>
         <Col className="order-md-1" md="6">
           <div className="pr-md-5">
@@ -132,7 +135,7 @@ export default function Home() {
         <title>Collaborative Curated Content | curatedli.st</title>
         <meta property="og:title" content="Collaborative Curated Content | curatedli.st" />
         <meta property="og:description" content="Collaborative curated content lists that won't suck. Share your content with others and get feedback. Review other's content." />
-        <meta property="og:image" content={require("assets/img/theme/checklist.svg")} />
+        <meta property="og:image" content={checklistImg} />
         <link rel="canonical" href="https://curatedli.st" />
       </Helmet>
       <Features />

--- a/src/components/list/Explore.js
+++ b/src/components/list/Explore.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import classnames from 'classnames';
 import { Helmet } from 'react-helmet';
 
+import checklistImg from 'assets/img/theme/checklist.svg';
+
 // reactstrap components
 import {
   Alert,
@@ -109,7 +111,7 @@ export default function Explore() {
           <title>Collaborative Curated Content | curatedli.st</title>
           <meta property="og:title" content="Collaborative Curated Content | curatedli.st" />
           <meta property="og:description" content="Collaborative curated content lists that won't suck. Share your content with others and get feedback. Review other's content." />
-          <meta property="og:image" content={require("assets/img/theme/checklist.svg")} />
+          <meta property="og:image" content={checklistImg} />
           <link rel="canonical" href="https://curatedli.st" />
         </Helmet>
         <div className="nav-wrapper mt--300 card-profile">

--- a/src/components/navbar/CustomNavbar.js
+++ b/src/components/navbar/CustomNavbar.js
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 
 import { setUser } from 'redux/actions';
 
+import logo from 'assets/img/logo.png';
+import logoBlack from 'assets/img/logo_black.png';
+
 // reactstrap components
 import {
   Container,
@@ -153,7 +156,7 @@ function CustomNavbar(props) {
             <NavbarBrand className="mr-lg-5" to="/" tag={Link}>
               <img
                 alt="Curatedli.st a collaborative curated content"
-                src={require("assets/img/logo.png")}
+                src={logo}
               />
             </NavbarBrand>
             {togler}
@@ -171,7 +174,7 @@ function CustomNavbar(props) {
                     <Link to={{ pathname: "/", state: { user } }}>
                       <img
                         alt="..."
-                        src={require("assets/img/logo_black.png")}
+                        src={logoBlack}
                       />
                     </Link>
                   </Col>


### PR DESCRIPTION
Part of the dependency-update series, plus a **live prod bug fix**.

## Fixes
- **Broken images** (logo, hero, feature) — they've rendered as `[object Module]`/blank since the CRA 3→5 migration, because webpack 5 returns a module object from `require()` for assets. Switched to ES `import`s (works for png + svg). *This is currently broken in production.*
- **Remove jQuery** — only a leftover CDN `<script>` in `public/index.html` (+ the BS4 bundle JS that depends on it) and a package.json dep; nothing in `src` uses it (reactstrap handles interactions).

## Intentionally NOT done
- **Bootstrap 5 / reactstrap 9:** the app is styled by the vendored **Argon (Bootstrap 4)** theme; reactstrap 9 emits BS5 classnames the theme doesn't define → would break layout sitewide. (bootstrap 4.6.2 / reactstrap 8.10.1 are already latest-in-major.)
- **FontAwesome 7:** v7 changed icon class handling and the github icon didn't render in testing; kept at 5.14.0.

## Verification
Built the production image, ran it headless, dumped the DOM: all `<img>` have real `/static/media/...` URLs (0 `[object Module]`), and screenshots confirm logo/hero/feature render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)