### PR TITLE
chore: stop sending stale token on public /search call

### DIFF
--- a/src/_services/list.service.js
+++ b/src/_services/list.service.js
@@ -115,15 +115,11 @@ async function deleteItem(idToken, list_id, item_id) {
   return result.item;
 }
 
-async function searchExternal(idToken, query) {
+async function searchExternal(query) {
+  // /search is public (catalog data, no auth) — no Authorization header needed.
   let url = new URL(import.meta.env.VITE_API_URL + "search/");
   url.search = new URLSearchParams({ q: query }).toString();
-  const requestOptions = {
-    headers: {
-      'Authorization': 'Bearer ' + idToken,
-    },
-  };
-  const res = await fetch(url, requestOptions).then(handleErrors);
+  const res = await fetch(url).then(handleErrors);
   const result = await res.json();
   return result.results;
 }

--- a/src/components/list/ListPage.js
+++ b/src/components/list/ListPage.js
@@ -96,7 +96,6 @@ function ListDetails(props) {
                     <Col md="5">
                       <FormGroup>
                         <ItemSearchField
-                          idToken={user.idToken}
                           value={props.values.name}
                           setFieldValue={props.setFieldValue} />
                       </FormGroup>

--- a/src/components/list/_itemSearchField.js
+++ b/src/components/list/_itemSearchField.js
@@ -13,7 +13,7 @@ const CATEGORY_ORDER = ['book', 'movie', 'music'];
 // that queries external catalogs (books / movies & TV / music). Selecting a
 // result autofills the Formik `name`, `url` and `pic_url` fields. Typing freely
 // (without selecting) still works — the backend then falls back to og:image.
-function ItemSearchField({ idToken, value, setFieldValue }) {
+function ItemSearchField({ value, setFieldValue }) {
   const [results, setResults] = useState([]);
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -38,7 +38,7 @@ function ItemSearchField({ idToken, value, setFieldValue }) {
       return;
     }
     setLoading(true);
-    listService.searchExternal(idToken, query)
+    listService.searchExternal(query)
       .then((res) => {
         setResults(res || []);
         setOpen(true);


### PR DESCRIPTION
Follow-up to making `/search` public (backend #7). The catalog typeahead no longer needs the short-lived Google ID token, so:

- `searchExternal(query)` drops the `idToken` param and `Authorization` header (plain `fetch`).
- `ItemSearchField` drops the now-unused `idToken` prop, and `ListPage` stops passing it.

No behavior change — `/search` is public — just removes the dead/expired-token plumbing. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)