### PR TITLE
feat: autofill item description from selected search result

### DIFF
--- a/src/components/list/_itemSearchField.js
+++ b/src/components/list/_itemSearchField.js
@@ -60,6 +60,7 @@ function ItemSearchField({ value, setFieldValue }) {
     setFieldValue('name', result.name);
     setFieldValue('url', result.url || '');
     setFieldValue('pic_url', result.pic_url || '');
+    setFieldValue('description', result.description || '');
     setOpen(false);
     setResults([]);
   };


### PR DESCRIPTION
The search result already carries a `description` (movie synopsis / book author+year / music genre) and shows it in the dropdown, but `onSelect` wasn't writing it to the form. Now it sets `description` via `setFieldValue` alongside name/url/pic_url. The field stays editable.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)