### PR TITLE
feat: lazily fetch full book synopsis on select

### DIFF
--- a/src/_services/list.service.js
+++ b/src/_services/list.service.js
@@ -11,6 +11,7 @@ export const listService = {
   addItem,
   deleteItem,
   searchExternal,
+  bookDescription,
 };
 
 async function getAll(filter) {
@@ -122,4 +123,13 @@ async function searchExternal(query) {
   const res = await fetch(url).then(handleErrors);
   const result = await res.json();
   return result.results;
+}
+
+async function bookDescription(workUrl) {
+  // Full Open Library synopsis for a selected book (public endpoint).
+  let url = new URL(import.meta.env.VITE_API_URL + "search/book");
+  url.search = new URLSearchParams({ url: workUrl }).toString();
+  const res = await fetch(url).then(handleErrors);
+  const result = await res.json();
+  return result.description;
 }

--- a/src/components/list/_itemSearchField.js
+++ b/src/components/list/_itemSearchField.js
@@ -63,6 +63,13 @@ function ItemSearchField({ value, setFieldValue }) {
     setFieldValue('description', result.description || '');
     setOpen(false);
     setResults([]);
+    // For books, lazily upgrade the author+year placeholder to the full
+    // Open Library synopsis (one extra fetch, only for the selected item).
+    if (result.category === 'book' && result.url) {
+      listService.bookDescription(result.url)
+        .then((desc) => { if (desc) setFieldValue('description', desc); })
+        .catch(() => { /* keep the placeholder description */ });
+    }
   };
 
   const grouped = CATEGORY_ORDER


### PR DESCRIPTION
Final piece of the book-description work. When a **book** result is selected, call the new `/search/book` endpoint to replace the `author + year` placeholder with Open Library's full synopsis. One extra fetch, only for the chosen item, so the typeahead stays fast; on error the placeholder is kept.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)