### PR TITLE
fix: handle expired session (401) by prompting re-login

### DIFF
--- a/src/_helpers/handleErrors.js
+++ b/src/_helpers/handleErrors.js
@@ -1,6 +1,19 @@
+import { clearSession } from '_helpers/auth';
+
 export function handleErrors(response) {
+  if (response.status === 401) {
+    // The Google ID token is short-lived (~1h) and not refreshed, so an
+    // authenticated request eventually 401s once it expires. Drop the stale
+    // session and send the user to log in again (a full navigation resets the
+    // empty Redux store on reload). Guard against a redirect loop on /login.
+    clearSession();
+    if (window.location.pathname !== '/login') {
+      window.location.assign('/login');
+    }
+    throw Error('Your session has expired. Please log in again.');
+  }
   if (!response.ok) {
-      throw Error(response.status);
+    throw Error(response.status);
   }
   return response;
 }


### PR DESCRIPTION
## Problem

`POST /lists/:id/items/` (and any authed call) returns **401** once the cached Google ID token expires (~1h, not refreshed). It surfaced as a cryptic `401` toast and left the dead session in place, so the user was stuck.

## Fix

`handleErrors` now detects `401`, clears the cached session (`clearSession()`), and redirects to `/login` so the user can re-authenticate and get a fresh token (a full navigation also resets the empty Redux store on reload). Guarded against a redirect loop when already on `/login`.

This is the behavior `auth.js` already documented ("until an authenticated request fails, at which point the caller should clear the session and prompt for login again") but that was never implemented.

`npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)